### PR TITLE
Improve export concurrency

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -8,6 +8,7 @@ struct AudioFileItem: Identifiable {
     let fileName: String
     var duration: TimeInterval
     var fadeDurationMs: Double
+    var progress: Double = 0.0
     let format: AudioFileFormat
     
     var durationString: String {

--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -12,6 +12,9 @@ struct SeamlessProcessor {
 
         DispatchQueue.global(qos: .userInitiated).async {
             do {
+                DispatchQueue.main.async {
+                    progress?(0.0)
+                }
                 // 1. Lecture du fichier audio source
                 let inputFile = try AVAudioFile(forReading: inputURL)
                 let formatDesc = inputFile.processingFormat


### PR DESCRIPTION
## Summary
- track per-file progress in `AudioFileItem`
- show progress in file table
- export files concurrently and update progress
- trigger progress callback at start of processing

## Testing
- `swift build` *(fails: invalid custom path 'SeamlessLooper')*

------
https://chatgpt.com/codex/tasks/task_e_684075025ae0832384961053fdac61c1