### PR TITLE
Use LoopSmith everywhere

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,21 +2,21 @@
 import PackageDescription
 
 let package = Package(
-    name: "SeamlessLooper",
+    name: "LoopSmith",
     platforms: [
         .macOS(.v12)
     ],
     products: [
-        .executable(name: "SeamlessLooper", targets: ["SeamlessLooper"])
+        .executable(name: "LoopSmith", targets: ["LoopSmith"])
     ],
     dependencies: [
         // Ajoute ici AudioKit si besoin plus tard
     ],
     targets: [
         .executableTarget(
-            name: "SeamlessLooper",
+            name: "LoopSmith",
             dependencies: [],
-            path: "SeamlessLooper"
+            path: "LoopSmith"
         )
     ]
-) 
+)


### PR DESCRIPTION
## Summary
- rename the Swift package and executable target from **SeamlessLooper** to **LoopSmith**

## Testing
- `swift package resolve`
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840759b6bb88323a05828618119eac2