### PR TITLE
Add drag-and-drop import and export prefix

### DIFF
--- a/LoopSmith/WaveformView.swift
+++ b/LoopSmith/WaveformView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct WaveformView: View {
+    var samples: [Float]
+
+    var body: some View {
+        GeometryReader { geometry in
+            let height = geometry.size.height
+            let width = geometry.size.width
+            let step = width / CGFloat(max(samples.count, 1))
+            Path { path in
+                for (index, amp) in samples.enumerated() {
+                    let x = CGFloat(index) * step
+                    let y = CGFloat(1 - amp) * height / 2
+                    path.move(to: CGPoint(x: x, y: y))
+                    path.addLine(to: CGPoint(x: x, y: height - y))
+                }
+            }
+            .stroke(Color.blue, lineWidth: 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow optional waveform preview and fade percent columns
- enable drag & drop import support
- remove output folder button and ask for folder on export
- export files prefixed with `LOOP_`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68407935cbbc83238f7dee7658f9ec14