### PR TITLE
Fix compile errors in ContentView and AudioFileItem

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -81,12 +81,12 @@ struct AudioFileItem: Identifiable {
 
         guard let data = buffer.floatChannelData?[0] else { return [] }
         let frameCount = Int(buffer.frameLength)
-        let stride = max(1, frameCount / samples)
+        let step = max(1, frameCount / samples)
         var result: [Float] = []
 
-        for i in stride(from: 0, to: frameCount, by: stride) {
+        for i in stride(from: 0, to: frameCount, by: step) {
             let start = i
-            let end = min(i + stride, frameCount)
+            let end = min(i + step, frameCount)
             var rms: Float = 0
             vDSP_measqv(data + start, 1, &rms, vDSP_Length(end - start))
             result.append(sqrt(rms))

--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -64,7 +64,7 @@ struct ContentView: View {
                 }
             }
             .frame(minHeight: 200)
-            .onDrop(of: [UTType.fileURL.identifier]) { providers in
+            .onDrop(of: [UTType.fileURL.identifier], isTargeted: nil) { providers in
                 handleDrop(providers: providers)
             }
             HStack {


### PR DESCRIPTION
## Summary
- fix `onDrop` signature in `ContentView`
- resolve stride naming conflict in `AudioFileItem`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68407ac677ac8323a519fb9b048a2254