### PR TITLE
Remove global fade, set default per-file fade, and fix progress

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -31,13 +31,14 @@ struct AudioFileItem: Identifiable {
         self.waveform = waveform
     }
     
-    static func load(url: URL, fadeDurationMs: Double, completion: @escaping (AudioFileItem?) -> Void) {
+    static func load(url: URL, completion: @escaping (AudioFileItem?) -> Void) {
         let asset = AVURLAsset(url: url)
         if #available(macOS 13.0, *) {
             Task {
                 do {
                     let duration = try await asset.load(.duration)
                     let seconds = CMTimeGetSeconds(duration)
+                    let fadeDurationMs = seconds * 1000 * 0.15
                     let waveform = generateWaveform(url: url)
                     DispatchQueue.main.async {
                         completion(AudioFileItem(url: url, fadeDurationMs: fadeDurationMs, duration: seconds, waveform: waveform))
@@ -54,6 +55,7 @@ struct AudioFileItem: Identifiable {
                 let status = asset.statusOfValue(forKey: "duration", error: &error)
                 if status == .loaded {
                     let duration = CMTimeGetSeconds(asset.duration)
+                    let fadeDurationMs = duration * 1000 * 0.15
                     let waveform = generateWaveform(url: url)
                     DispatchQueue.main.async {
                         completion(AudioFileItem(url: url, fadeDurationMs: fadeDurationMs, duration: duration, waveform: waveform))

--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -5,7 +5,6 @@ import AppKit
 struct ContentView: View {
     @State private var audioFiles: [AudioFileItem] = []
     @State private var isImporting: Bool = false
-    @State private var fadeDurationMs: Double = 30_000.0
     @State private var isExporting: Bool = false
     @State private var exportProgress: Double = 0.0
     @State private var selectedFormat: AudioFileFormat = .wav
@@ -21,15 +20,7 @@ struct ContentView: View {
                     .font(.caption)
             }
             .padding(.vertical)
-            HStack {
-                Text("Global fade (s):")
-                Slider(value: Binding(
-                    get: { fadeDurationMs / 1000 },
-                    set: { fadeDurationMs = $0 * 1000 }
-                ), in: 1...60)
-                Text("\(Int(fadeDurationMs / 1000)) s")
-            }
-            .padding(.bottom)
+            
             Table(audioFiles) {
                 TableColumn("Name") { file in
                     Text(file.fileName)
@@ -59,8 +50,8 @@ struct ContentView: View {
                     Text(String(format: "%.0f%%", percent))
                 }
                 TableColumn("Progress") { file in
-                    ProgressView(value: file.progress, total: 1.0)
-                        .frame(width: 100)
+                    ProgressBar(progress: file.progress)
+                        .frame(width: 100, height: 10)
                 }
             }
             .frame(minHeight: 200)
@@ -87,7 +78,7 @@ struct ContentView: View {
         switch result {
         case .success(let urls):
             for url in urls {
-                AudioFileItem.load(url: url, fadeDurationMs: fadeDurationMs) { item in
+                AudioFileItem.load(url: url) { item in
                     if let item = item {
                         DispatchQueue.main.async {
                             audioFiles.append(item)
@@ -107,7 +98,7 @@ struct ContentView: View {
                     if let urlData = data as? Data,
                        let url = NSURL(absoluteURLWithDataRepresentation: urlData, relativeTo: nil) as URL? ,
                        AudioFileFormat(url: url) != nil {
-                        AudioFileItem.load(url: url, fadeDurationMs: fadeDurationMs) { item in
+                        AudioFileItem.load(url: url) { item in
                             if let item = item {
                                 DispatchQueue.main.async {
                                     audioFiles.append(item)

--- a/LoopSmith/ProgressBar.swift
+++ b/LoopSmith/ProgressBar.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+struct ProgressBar: View {
+    var progress: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                Rectangle()
+                    .fill(Color.blue)
+                    .frame(width: CGFloat(max(0.0, min(1.0, progress))) * geometry.size.width)
+            }
+            .cornerRadius(4)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove global fade slider from UI
- default each audio file fade to 15% of its duration
- add custom `ProgressBar` view and use it in the file table

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68407c5ddd208323b845f5847b1da3da