### PR TITLE
Update fade UI and add preview

### DIFF
--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -41,22 +41,23 @@ struct ContentView: View {
                     WaveformView(samples: file.waveform)
                         .frame(height: 30)
                 }
-                TableColumn("Fade (s)") { file in
+                TableColumn("Fade (%)") { file in
                     HStack {
                         Slider(value: Binding(
-                            get: { file.fadeDurationMs / 1000 },
-                            set: { newValue in
+                            get: {
+                                file.duration > 0 ? (file.fadeDurationMs / (file.duration * 1000)) * 100 : 0
+                            },
+                            set: { newPercent in
                                 if let idx = audioFiles.firstIndex(where: { $0.id == file.id }) {
-                                    audioFiles[idx].fadeDurationMs = newValue * 1000
+                                    audioFiles[idx].fadeDurationMs = (newPercent / 100) * audioFiles[idx].duration * 1000
                                 }
                             }
-                        ), in: 1...60)
-                        Text("\(Int(file.fadeDurationMs / 1000)) s")
+                        ), in: 0...100)
+                        Text(String(format: "%.0f%%", file.duration > 0 ? (file.fadeDurationMs / (file.duration * 1000)) * 100 : 0))
                     }
                 }
-                TableColumn("Fade %") { file in
-                    let percent = file.duration > 0 ? (file.fadeDurationMs / (file.duration * 1000)) * 100 : 0
-                    Text(String(format: "%.0f%%", percent))
+                TableColumn("Preview") { file in
+                    PreviewButton(file: file)
                 }
                 TableColumn("Progress") { file in
                     ProgressView(value: file.progress, total: 1.0)

--- a/LoopSmith/PreviewPlayer.swift
+++ b/LoopSmith/PreviewPlayer.swift
@@ -1,0 +1,78 @@
+import Foundation
+import AVFoundation
+import SwiftUI
+
+class PreviewPlayer: NSObject, ObservableObject, AVAudioPlayerDelegate {
+    @Published var isPlaying: Bool = false
+    private var player: AVAudioPlayer?
+
+    func play(url: URL) {
+        do {
+            player = try AVAudioPlayer(contentsOf: url)
+            player?.delegate = self
+            player?.play()
+            isPlaying = true
+        } catch {
+            print("PreviewPlayer error:", error)
+            isPlaying = false
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        isPlaying = false
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        isPlaying = false
+        self.player = nil
+    }
+}
+
+struct PreviewButton: View {
+    var file: AudioFileItem
+    @StateObject private var player = PreviewPlayer()
+    @State private var isProcessing = false
+
+    var body: some View {
+        Button(action: toggle) {
+            if isProcessing {
+                ProgressView()
+            } else {
+                Text(player.isPlaying ? "Stop" : "Preview")
+            }
+        }
+        .disabled(isProcessing)
+    }
+
+    private func toggle() {
+        if player.isPlaying {
+            player.stop()
+            return
+        }
+
+        isProcessing = true
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension(file.format.rawValue)
+
+        SeamlessProcessor.process(
+            inputURL: file.url,
+            outputURL: tmpURL,
+            fadeDurationMs: file.fadeDurationMs,
+            format: file.format,
+            progress: nil
+        ) { result in
+            DispatchQueue.main.async {
+                self.isProcessing = false
+                switch result {
+                case .success:
+                    self.player.play(url: tmpURL)
+                case .failure(let error):
+                    print("Preview processing error:", error)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- control per-file fades using percentages instead of seconds
- add a Preview button to listen to the crossfade

## Testing
- `swift build -c release` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68407cc5c9848323bd0fb37f5d21daec