### PR TITLE
Fix preview crash

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -58,7 +58,7 @@ struct SeamlessProcessor {
 
                     let crossfadeStart = rightLen - fadeSamples / 2
                     let start = max(0, crossfadeStart)
-                    let fadeLength = min(total - start, fadeSamples)
+                    let fadeLength = min(fadeSamples, rightLen - start)
 
                     if fadeLength > 0 {
                         for i in 0..<fadeLength {


### PR DESCRIPTION
## Summary
- fix crossfade length to avoid exceeding input buffer

## Testing
- `swift test` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68407fb0f1e4832387bbab226f372121