### PR TITLE
Replace deprecated cblas_scopy

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -53,7 +53,7 @@ struct SeamlessProcessor {
                     let output = outputChannels[ch]
 
                     // Copie initiale du fichier complet
-                    cblas_scopy(Int32(total), input, 1, output, 1)
+                    output.assign(from: input, count: total)
 
                     // Calcul de la longueur de fondu
                     let fade = min(fadeSamples, total / 2)
@@ -77,9 +77,9 @@ struct SeamlessProcessor {
                     temp.initialize(repeating: 0, count: total)
                     defer { temp.deallocate() }
 
-                    cblas_scopy(Int32(rightLen), output + midFrame, 1, temp, 1)
-                    cblas_scopy(Int32(midFrame), output, 1, temp + rightLen, 1)
-                    cblas_scopy(Int32(total), temp, 1, output, 1)
+                    temp.assign(from: output + midFrame, count: rightLen)
+                    temp.advanced(by: rightLen).assign(from: output, count: midFrame)
+                    output.assign(from: temp, count: total)
 
                     // Appel du callback de progression
                     let percent = Double(ch + 1) / Double(numChannels)


### PR DESCRIPTION
## Summary
- remove usages of deprecated Accelerate `cblas_scopy`
- replace with Swift's `assign(from:count:)`

## Testing
- `swift test -c release` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_684083492eec8323a311659ac93660f7