### PR TITLE
Add exported path info and clearing option

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -10,6 +10,7 @@ struct AudioFileItem: Identifiable {
     var duration: TimeInterval
     var fadeDurationMs: Double
     var progress: Double = 0.0
+    var exportedURL: URL? = nil
     var waveform: [Float] = []
     let format: AudioFileFormat
     


### PR DESCRIPTION
## Summary
- show a link to the exported folder when a file finishes exporting
- display the exported path in a dedicated column
- add a button to clear finished exports

## Testing
- `swift build -c release` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840845268c08323bd1a3fe5dd32c4d2