### PR TITLE
Fix export completion text and open folder

### DIFF
--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -52,7 +52,9 @@ struct ContentView: View {
                 }
                 TableColumn("Progress") { file in
                     if let url = file.exportedURL, file.progress >= 1.0 {
-                        Link("done!", destination: url.deletingLastPathComponent())
+                        Button("Open Folder") {
+                            NSWorkspace.shared.open(url.deletingLastPathComponent())
+                        }
                     } else {
                         ProgressBar(progress: file.progress)
                             .frame(width: 100, height: 10)


### PR DESCRIPTION
## Summary
- show an "Open Folder" button once file export is finished

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_684086304f6c8323a1375ccea19fda24