### PR TITLE
Add Rhythm Sync mode for transient-aware crossfades

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -12,6 +12,7 @@ struct AudioFileItem: Identifiable {
     var progress: Double = 0.0
     var exportedURL: URL? = nil
     var waveform: [Float] = []
+    var rhythmSync: Bool = false
     let format: AudioFileFormat
     
     var durationString: String {
@@ -20,7 +21,7 @@ struct AudioFileItem: Identifiable {
         return String(format: "%d:%02d", minutes, seconds)
     }
     
-    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = []) {
+    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], rhythmSync: Bool = false) {
         self.url = url
         self.fileName = url.lastPathComponent
         self.fadeDurationMs = fadeDurationMs
@@ -30,6 +31,7 @@ struct AudioFileItem: Identifiable {
         self.format = format
         self.duration = duration
         self.waveform = waveform
+        self.rhythmSync = rhythmSync
     }
     
     static func load(url: URL, completion: @escaping (AudioFileItem?) -> Void) {

--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -47,6 +47,17 @@ struct ContentView: View {
                         Text(String(format: "%.0f%%", file.duration > 0 ? (file.fadeDurationMs / (file.duration * 1000)) * 100 : 0))
                     }
                 }
+                TableColumn("Rhythm Sync") { file in
+                    Toggle("", isOn: Binding(
+                        get: { file.rhythmSync },
+                        set: { newVal in
+                            if let idx = audioFiles.firstIndex(where: { $0.id == file.id }) {
+                                audioFiles[idx].rhythmSync = newVal
+                            }
+                        }
+                    ))
+                    .labelsHidden()
+                }
                 TableColumn("Preview") { file in
                     PreviewButton(file: file)
                 }
@@ -157,6 +168,7 @@ struct ContentView: View {
                     outputURL: outputURL,
                     fadeDurationMs: file.fadeDurationMs,
                     format: selectedFormat,
+                    rhythmSync: file.rhythmSync,
                     progress: { percent in
                         updateFileProgress(fileID: file.id, progress: percent)
                     }

--- a/LoopSmith/PreviewPlayer.swift
+++ b/LoopSmith/PreviewPlayer.swift
@@ -74,15 +74,16 @@ struct PreviewButton: View {
             outputURL: tmpURL,
             fadeDurationMs: file.fadeDurationMs,
             format: file.format,
+            rhythmSync: file.rhythmSync,
             progress: nil
         ) { result in
             DispatchQueue.main.async {
                 self.isProcessing = false
                 switch result {
-                case .success:
+                case .success(let centerTime):
                     let fadeSeconds = file.fadeDurationMs / 1000
-                    let startTime = max(0, (file.duration / 2) - (fadeSeconds / 2))
-                    self.player.play(url: tmpURL, startTime: startTime, duration: fadeSeconds)
+                    let start = max(0, centerTime - fadeSeconds / 2)
+                    self.player.play(url: tmpURL, startTime: start, duration: fadeSeconds)
                 case .failure(let error):
                     print("Preview processing error:", error)
                 }


### PR DESCRIPTION
## Summary
- introduce `rhythmSync` flag in `AudioFileItem`
- add *Rhythm Sync* checkbox column in the table
- allow preview/export to process with transient-aware crossfades
- compute optimal crossfade offset in `SeamlessProcessor`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_684085931abc8323899ad5d10bfa47ba