### PR TITLE
Fix trailing closure compile error

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -11,11 +11,11 @@ struct SeamlessProcessor {
                         progress: ((Double) -> Void)? = nil,
                         completion: @escaping (Result<Double, Error>) -> Void) {
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .userInitiated).async(execute: {
             do {
-                DispatchQueue.main.async {
+                DispatchQueue.main.async(execute: {
                     progress?(0.0)
-                }
+                })
                 // 1. Lecture du fichier audio source
                 let inputFile = try AVAudioFile(forReading: inputURL)
                 let formatDesc = inputFile.processingFormat
@@ -103,9 +103,9 @@ struct SeamlessProcessor {
 
                     // Appel du callback de progression
                     let percent = Double(ch + 1) / Double(numChannels)
-                    DispatchQueue.main.async {
+                    DispatchQueue.main.async(execute: {
                         progress?(percent)
-                    }
+                    })
                 }
 
                 // 4. Conversion en buffer interleaved si nécessaire
@@ -161,6 +161,6 @@ struct SeamlessProcessor {
             } catch {
                 completion(.failure(error))
             }
-        }
+        })
     }
 }


### PR DESCRIPTION
## Summary
- fix `DispatchQueue.async` closure syntax in `SeamlessProcessor`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68408c612d408323b2e834ded5beb1d6