### PR TITLE
Fix DispatchQueue closure parameter

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -11,11 +11,11 @@ struct SeamlessProcessor {
                         progress: ((Double) -> Void)? = nil,
                         completion: @escaping (Result<Double, Error>) -> Void) {
 
-        DispatchQueue.global(qos: .userInitiated).async(execute: {
+        DispatchQueue.global(qos: .userInitiated).async {
             do {
-                DispatchQueue.main.async(execute: {
+                DispatchQueue.main.async {
                     progress?(0.0)
-                })
+                }
                 // 1. Lecture du fichier audio source
                 let inputFile = try AVAudioFile(forReading: inputURL)
                 let formatDesc = inputFile.processingFormat
@@ -103,9 +103,9 @@ struct SeamlessProcessor {
 
                     // Appel du callback de progression
                     let percent = Double(ch + 1) / Double(numChannels)
-                    DispatchQueue.main.async(execute: {
+                    DispatchQueue.main.async {
                         progress?(percent)
-                    })
+                    }
                 }
 
                 // 4. Conversion en buffer interleaved si nécessaire


### PR DESCRIPTION
## Summary
- correct `DispatchQueue.async` calls in `SeamlessProcessor`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840c62411348323a4405668cc7d229e