### PR TITLE
Fix trailing parenthesis in SeamlessProcessor

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -161,6 +161,6 @@ struct SeamlessProcessor {
             } catch {
                 completion(.failure(error))
             }
-        })
+        }
     }
 }


### PR DESCRIPTION
## Summary
- fix unmatched closing parenthesis at end of `SeamlessProcessor.process`

## Testing
- `swift test` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840cc6ce13c8323924a4f7ebf675a5c