### PR TITLE
Add BPM detection with automatic fade quantization

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -13,6 +13,7 @@ struct AudioFileItem: Identifiable {
     var exportedURL: URL? = nil
     var waveform: [Float] = []
     var rhythmSync: Bool = false
+    var bpm: Double? = nil
     let format: AudioFileFormat
 
     /// Returns the output URL for this file when exported to the given directory
@@ -29,7 +30,7 @@ struct AudioFileItem: Identifiable {
         return String(format: "%d:%02d", minutes, seconds)
     }
     
-    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], rhythmSync: Bool = false) {
+    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], rhythmSync: Bool = false, bpm: Double? = nil) {
         self.url = url
         self.fileName = url.lastPathComponent
         self.fadeDurationMs = fadeDurationMs
@@ -40,6 +41,7 @@ struct AudioFileItem: Identifiable {
         self.duration = duration
         self.waveform = waveform
         self.rhythmSync = rhythmSync
+        self.bpm = bpm
     }
     
     static func load(url: URL, completion: @escaping (AudioFileItem?) -> Void) {
@@ -51,8 +53,10 @@ struct AudioFileItem: Identifiable {
                     let seconds = CMTimeGetSeconds(duration)
                     let fadeDurationMs = seconds * 1000 * 0.15
                     let waveform = generateWaveform(url: url)
+                    let bpm = BPMDetector.detect(url: url)
+                    let adjustedFade = bpm != nil ? (60.0 / (bpm!)) * 4 * 1000 : fadeDurationMs
                     DispatchQueue.main.async {
-                        completion(AudioFileItem(url: url, fadeDurationMs: fadeDurationMs, duration: seconds, waveform: waveform))
+                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: seconds, waveform: waveform, rhythmSync: false, bpm: bpm))
                     }
                 } catch {
                     DispatchQueue.main.async {
@@ -68,8 +72,10 @@ struct AudioFileItem: Identifiable {
                     let duration = CMTimeGetSeconds(asset.duration)
                     let fadeDurationMs = duration * 1000 * 0.15
                     let waveform = generateWaveform(url: url)
+                    let bpm = BPMDetector.detect(url: url)
+                    let adjustedFade = bpm != nil ? (60.0 / (bpm!)) * 4 * 1000 : fadeDurationMs
                     DispatchQueue.main.async {
-                        completion(AudioFileItem(url: url, fadeDurationMs: fadeDurationMs, duration: duration, waveform: waveform))
+                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: duration, waveform: waveform, rhythmSync: false, bpm: bpm))
                     }
                 } else {
                     DispatchQueue.main.async {

--- a/LoopSmith/BPMDetector.swift
+++ b/LoopSmith/BPMDetector.swift
@@ -1,0 +1,63 @@
+import Foundation
+import AVFoundation
+import Accelerate
+
+enum BPMDetector {
+    /// Returns the estimated beats-per-minute for the given audio file.
+    /// The algorithm is lightweight and uses envelope following with
+    /// autocorrelation. It works best on percussive material.
+    static func detect(url: URL) -> Double? {
+        guard let file = try? AVAudioFile(forReading: url) else { return nil }
+        let format = file.processingFormat
+        let sampleRate = format.sampleRate
+        let frameCount = Int(file.length)
+        guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount)) else { return nil }
+        do {
+            try file.read(into: buffer)
+        } catch {
+            return nil
+        }
+        guard let channel = buffer.floatChannelData?[0] else { return nil }
+
+        // Envelope follower
+        let hop = Int(sampleRate / 200) // ~5ms
+        let envCount = frameCount / hop
+        var envelope = [Float](repeating: 0, count: envCount)
+        for i in 0..<envCount {
+            let start = i * hop
+            let end = min(start + hop, frameCount)
+            var rms: Float = 0
+            vDSP_measqv(channel + start, 1, &rms, vDSP_Length(end - start))
+            envelope[i] = rms
+        }
+        // Differentiate and half-wave rectify
+        var diff = [Float](repeating: 0, count: envCount - 1)
+        for i in 1..<envCount {
+            diff[i-1] = max(0, envelope[i] - envelope[i-1])
+        }
+
+        let len = diff.count
+        var autocorr = [Float](repeating: 0, count: len)
+        vDSP_conv(diff, 1, diff.reversed(), 1, &autocorr, 1, vDSP_Length(len), vDSP_Length(len))
+
+        let minBPM = 60.0
+        let maxBPM = 200.0
+        let minLag = Int(sampleRate * 60.0 / maxBPM / Double(hop))
+        let maxLag = Int(sampleRate * 60.0 / minBPM / Double(hop))
+
+        var bestLag = 0
+        var bestVal: Float = 0
+        for lag in minLag..<min(maxLag, len) {
+            let val = autocorr[lag]
+            if val > bestVal {
+                bestVal = val
+                bestLag = lag
+            }
+        }
+        if bestLag > 0 {
+            let bpm = 60.0 * sampleRate / Double(bestLag * hop)
+            return bpm
+        }
+        return nil
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LoopSmith
+
+This project provides tools for seamless looping of audio files.
+
+## Features
+- Import multiple audio files, adjust fade lengths and preview loops.
+- Rhythm sync option to align crossfades.
+- BPM detection and automatic fade adjustment to match one measure.
+- Simple auto-quantization of loops on export.
+
+## Building
+This project targets macOS and requires the macOS SDK. Use Xcode or the Swift
+package manager on macOS to build.


### PR DESCRIPTION
## Summary
- add simple README
- add BPMDetector helper for lightweight BPM estimation
- store detected bpm inside `AudioFileItem`
- adjust fade duration to a full measure when BPM is known

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840d334f22083239aa709d4bff1f5d9