### PR TITLE
Add spectral loop analyser

### DIFF
--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -38,22 +38,12 @@ struct SeamlessProcessor {
                 let fadeSamples = max(1, Int(sampleRate * fadeDurationMs / 1000.0))
 
                 var offsetFrames = 0
-                if rhythmSync {
-                    let searchRange = min(fadeSamples, max(0, total - fadeSamples * 2))
-                    if searchRange > 0, numChannels > 0 {
-                        let channel = inputChannels[0]
-                        var bestScore: Float = .greatestFiniteMagnitude
-                        for off in (-searchRange)...searchRange {
-                            let endStart = total - fadeSamples + off
-                            if endStart < 0 || endStart + fadeSamples > total { continue }
-                            var diff: Float = 0
-                            vDSP_distancesq(channel + endStart, 1, channel, 1, &diff, vDSP_Length(fadeSamples))
-                            if diff < bestScore {
-                                bestScore = diff
-                                offsetFrames = off
-                            }
-                        }
-                    }
+                if rhythmSync, numChannels > 0 {
+                    let channel = inputChannels[0]
+                    offsetFrames = SpectralLoopAnalyzer.bestOffset(
+                        channel: channel,
+                        totalFrames: total,
+                        fadeSamples: fadeSamples)
                 }
 
                 // 2. Création du buffer de sortie

--- a/LoopSmith/SpectralLoopAnalyzer.swift
+++ b/LoopSmith/SpectralLoopAnalyzer.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Accelerate
+
+struct SpectralLoopAnalyzer {
+    static func bestOffset(channel: UnsafePointer<Float>,
+                           totalFrames: Int,
+                           fadeSamples: Int) -> Int {
+        let searchRange = min(fadeSamples, max(0, totalFrames - fadeSamples * 2))
+        if searchRange <= 0 { return 0 }
+
+        let log2n = vDSP_Length(log2(Double(fadeSamples)))
+        guard let dft = vDSP.DFT(count: fadeSamples,
+                                 direction: .forward,
+                                 transformType: .real,
+                                 ofType: Float.self) else {
+            return 0
+        }
+
+        var window = [Float](repeating: 0, count: fadeSamples)
+        vDSP_hann_window(&window, vDSP_Length(fadeSamples), Int32(vDSP_HANN_NORM))
+
+        var startSegment = [Float](repeating: 0, count: fadeSamples)
+        vDSP_vmul(channel, 1, window, 1, &startSegment, 1, vDSP_Length(fadeSamples))
+
+        var startReal = [Float](repeating: 0, count: fadeSamples/2)
+        var startImag = [Float](repeating: 0, count: fadeSamples/2)
+        dft.transform(startSegment, realOutput: &startReal, imaginaryOutput: &startImag)
+        var startMag = [Float](repeating: 0, count: fadeSamples/2)
+        vDSP.squareMagnitudes(startReal, startImag, result: &startMag)
+        vDSP.sqrt(startMag, result: &startMag)
+
+        var candidate = [Float](repeating: 0, count: fadeSamples)
+        var candReal = [Float](repeating: 0, count: fadeSamples/2)
+        var candImag = [Float](repeating: 0, count: fadeSamples/2)
+        var candMag = [Float](repeating: 0, count: fadeSamples/2)
+
+        var bestScore: Float = .greatestFiniteMagnitude
+        var bestOffset = 0
+
+        for off in (-searchRange)...searchRange {
+            let endStart = totalFrames - fadeSamples + off
+            if endStart < 0 || endStart + fadeSamples > totalFrames { continue }
+
+            vDSP_vmul(channel + endStart, 1, window, 1, &candidate, 1, vDSP_Length(fadeSamples))
+            dft.transform(candidate, realOutput: &candReal, imaginaryOutput: &candImag)
+            vDSP.squareMagnitudes(candReal, candImag, result: &candMag)
+            vDSP.sqrt(candMag, result: &candMag)
+
+            var diff: Float = 0
+            vDSP_distancesq(&candMag, 1, &startMag, 1, &diff, vDSP_Length(fadeSamples/2))
+            if diff < bestScore {
+                bestScore = diff
+                bestOffset = off
+            }
+        }
+
+        return bestOffset
+    }
+}


### PR DESCRIPTION
## Summary
- add `SpectralLoopAnalyzer` to find the best loop offset using FFT magnitude matching
- use the new analyser in `SeamlessProcessor` when rhythmic sync is enabled

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6840d345314c8323bd083605fa3730e1