### PR TITLE
Add rhythmic recomposition toggle

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -13,6 +13,7 @@ struct AudioFileItem: Identifiable {
     var exportedURL: URL? = nil
     var waveform: [Float] = []
     var rhythmSync: Bool = false
+    var rhythmicRecomposition: Bool = false
     var bpm: Double? = nil
     let format: AudioFileFormat
 
@@ -30,7 +31,7 @@ struct AudioFileItem: Identifiable {
         return String(format: "%d:%02d", minutes, seconds)
     }
     
-    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], rhythmSync: Bool = false, bpm: Double? = nil) {
+    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], rhythmSync: Bool = false, rhythmicRecomposition: Bool = false, bpm: Double? = nil) {
         self.url = url
         self.fileName = url.lastPathComponent
         self.fadeDurationMs = fadeDurationMs
@@ -41,6 +42,7 @@ struct AudioFileItem: Identifiable {
         self.duration = duration
         self.waveform = waveform
         self.rhythmSync = rhythmSync
+        self.rhythmicRecomposition = rhythmicRecomposition
         self.bpm = bpm
     }
     
@@ -56,7 +58,7 @@ struct AudioFileItem: Identifiable {
                     let bpm = BPMDetector.detect(url: url)
                     let adjustedFade = bpm != nil ? (60.0 / (bpm!)) * 4 * 1000 : fadeDurationMs
                     DispatchQueue.main.async {
-                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: seconds, waveform: waveform, rhythmSync: false, bpm: bpm))
+                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: seconds, waveform: waveform, rhythmSync: false, rhythmicRecomposition: false, bpm: bpm))
                     }
                 } catch {
                     DispatchQueue.main.async {
@@ -75,7 +77,7 @@ struct AudioFileItem: Identifiable {
                     let bpm = BPMDetector.detect(url: url)
                     let adjustedFade = bpm != nil ? (60.0 / (bpm!)) * 4 * 1000 : fadeDurationMs
                     DispatchQueue.main.async {
-                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: duration, waveform: waveform, rhythmSync: false, bpm: bpm))
+                        completion(AudioFileItem(url: url, fadeDurationMs: adjustedFade, duration: duration, waveform: waveform, rhythmSync: false, rhythmicRecomposition: false, bpm: bpm))
                     }
                 } else {
                     DispatchQueue.main.async {

--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -59,6 +59,17 @@ struct ContentView: View {
                     ))
                     .labelsHidden()
                 }
+                TableColumn("Rhythmic Recomposition") { file in
+                    Toggle("", isOn: Binding(
+                        get: { file.rhythmicRecomposition },
+                        set: { newVal in
+                            if let idx = audioFiles.firstIndex(where: { $0.id == file.id }) {
+                                audioFiles[idx].rhythmicRecomposition = newVal
+                            }
+                        }
+                    ))
+                    .labelsHidden()
+                }
                 TableColumn("Preview") { file in
                     PreviewButton(file: file)
                 }
@@ -181,6 +192,7 @@ struct ContentView: View {
                     fadeDurationMs: file.fadeDurationMs,
                     format: selectedFormat,
                     rhythmSync: file.rhythmSync,
+                    rhythmicRecomposition: file.rhythmicRecomposition,
                     progress: { percent in
                         updateFileProgress(fileID: file.id, progress: percent)
                     }

--- a/LoopSmith/PreviewPlayer.swift
+++ b/LoopSmith/PreviewPlayer.swift
@@ -5,7 +5,7 @@ import CryptoKit
 
 private struct PreviewCache {
     private static func key(for file: AudioFileItem) -> String {
-        "\(file.url.path)-\(file.fadeDurationMs)-\(file.rhythmSync)"
+        "\(file.url.path)-\(file.fadeDurationMs)-\(file.rhythmSync)-\(file.rhythmicRecomposition)"
     }
 
     private static func hash(_ string: String) -> String {
@@ -115,6 +115,7 @@ struct PreviewButton: View {
             fadeDurationMs: file.fadeDurationMs,
             format: file.format,
             rhythmSync: file.rhythmSync,
+            rhythmicRecomposition: file.rhythmicRecomposition,
             progress: nil
         ) { result in
             DispatchQueue.main.async {

--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -8,6 +8,7 @@ struct SeamlessProcessor {
                         fadeDurationMs: Double,
                         format: AudioFileFormat,
                         rhythmSync: Bool,
+                        rhythmicRecomposition: Bool,
                         progress: ((Double) -> Void)? = nil,
                         completion: @escaping (Result<Double, Error>) -> Void) {
 
@@ -54,6 +55,12 @@ struct SeamlessProcessor {
                             }
                         }
                     }
+                }
+
+                // Placeholder for future rhythmic recomposition algorithm
+                // Currently this flag has no effect on processing
+                if rhythmicRecomposition {
+                    // TODO: implement algorithm
                 }
 
                 // 2. Création du buffer de sortie

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project provides tools for seamless looping of audio files.
 ## Features
 - Import multiple audio files, adjust fade lengths and preview loops.
 - Rhythm sync option to align crossfades.
+- Rhythmic recomposition toggle per file.
 - BPM detection and automatic fade adjustment to match one measure.
 - Simple auto-quantization of loops on export.
 


### PR DESCRIPTION
## Summary
- add `rhythmicRecomposition` property to `AudioFileItem`
- expose toggle for "Rhythmic Recomposition" in table view
- pass new option through preview and export processing
- extend preview cache key
- document feature in README

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6841544a98388323a707f9a332c58490