### PR TITLE
Fix DFT transform type

### DIFF
--- a/LoopSmith/SpectralLoopAnalyzer.swift
+++ b/LoopSmith/SpectralLoopAnalyzer.swift
@@ -11,7 +11,7 @@ struct SpectralLoopAnalyzer {
         let log2n = vDSP_Length(log2(Double(fadeSamples)))
         guard let dft = vDSP.DFT(count: fadeSamples,
                                  direction: .forward,
-                                 transformType: .realComplex,
+                                 transformType: .realForward,
                                  ofType: Float.self) else {
             return 0
         }


### PR DESCRIPTION
## Summary
- update SpectralLoopAnalyzer to use realForward DFT transform type

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68416367297c8323ac441f727dd96925