### PR TITLE
Improve BPM-synced crossfading

### DIFF
--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -262,6 +262,7 @@ struct ContentView: View {
                     fadeDurationMs: file.fadeDurationMs,
                     format: selectedFormat,
                     rhythmSync: file.rhythmSync,
+                    bpm: file.bpm,
                     rhythmicRecomposition: file.rhythmicRecomposition,
                     progress: { percent in
                         updateFileProgress(fileID: file.id, progress: percent)

--- a/LoopSmith/PreviewPlayer.swift
+++ b/LoopSmith/PreviewPlayer.swift
@@ -5,7 +5,7 @@ import CryptoKit
 
 private struct PreviewCache {
     private static func key(for file: AudioFileItem) -> String {
-        "\(file.url.path)-\(file.fadeDurationMs)-\(file.rhythmSync)-\(file.rhythmicRecomposition)"
+        "\(file.url.path)-\(file.fadeDurationMs)-\(file.rhythmSync)-\(file.rhythmicRecomposition)-\(file.bpm ?? -1)"
     }
 
     private static func hash(_ string: String) -> String {
@@ -121,6 +121,7 @@ struct PreviewButton: View {
             fadeDurationMs: file.fadeDurationMs,
             format: file.format,
             rhythmSync: file.rhythmSync,
+            bpm: file.bpm,
             rhythmicRecomposition: file.rhythmicRecomposition,
             progress: nil
         ) { result in

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides tools for seamless looping of audio files.
 
 ## Features
 - Import multiple audio files, adjust fade lengths and preview loops.
-- Rhythm sync option to align crossfades.
+- Rhythm sync option aligns crossfades to the detected BPM and tweaks the overlap for smoother loops.
 - Rhythmic recomposition toggle per file.
 - BPM detection and automatic fade adjustment to match one measure.
 - Simple auto-quantization of loops on export.


### PR DESCRIPTION
## Summary
- refine crossfade processing with BPM-aware rhythm sync
- pass BPM value through ContentView and PreviewPlayer
- include BPM in preview cache key
- clarify README

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68416833fa188323bec7a6b814d48938