### PR TITLE
Fix DFT API usage

### DIFF
--- a/LoopSmith/SpectralLoopAnalyzer.swift
+++ b/LoopSmith/SpectralLoopAnalyzer.swift
@@ -8,12 +8,12 @@ struct SpectralLoopAnalyzer {
         let searchRange = min(fadeSamples, max(0, totalFrames - fadeSamples * 2))
         if searchRange <= 0 { return 0 }
 
-        // The vDSP.DFT initializer can throw and returns a concrete instance
-        // rather than an optional. Use `try?` so failures simply return 0.
-        guard let dft = try? vDSP.DFT(count: fadeSamples,
-                                      direction: .forward,
-                                      transformType: .complexReal,
-                                      ofType: Float.self) else {
+        // The vDSP.DFT initializer returns an optional instance.  If the
+        // transform cannot be created, simply return offset 0.
+        guard let dft = vDSP.DFT(count: fadeSamples,
+                                 direction: .forward,
+                                 transformType: .complexReal,
+                                 ofType: Float.self) else {
             return 0
         }
 
@@ -25,7 +25,7 @@ struct SpectralLoopAnalyzer {
 
         var startReal = [Float](repeating: 0, count: fadeSamples/2)
         var startImag = [Float](repeating: 0, count: fadeSamples/2)
-        dft.transform(input: startSegment,
+        dft.transform(startSegment,
                       outputReal: &startReal,
                       outputImaginary: &startImag)
         var startMag = [Float](repeating: 0, count: fadeSamples/2)
@@ -48,7 +48,7 @@ struct SpectralLoopAnalyzer {
             if endStart < 0 || endStart + fadeSamples > totalFrames { continue }
 
             vDSP_vmul(channel + endStart, 1, window, 1, &candidate, 1, vDSP_Length(fadeSamples))
-            dft.transform(input: candidate,
+            dft.transform(candidate,
                           outputReal: &candReal,
                           outputImaginary: &candImag)
             for i in 0..<(fadeSamples/2) {


### PR DESCRIPTION
## Summary
- correct `vDSP.DFT` initialization handling
- update `transform` calls for latest Accelerate API

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_684168d75ba08323a1267f3edb6e454e