### PR TITLE
Fix compile errors in SpectralLoopAnalyzer

### DIFF
--- a/LoopSmith/SpectralLoopAnalyzer.swift
+++ b/LoopSmith/SpectralLoopAnalyzer.swift
@@ -10,10 +10,10 @@ struct SpectralLoopAnalyzer {
 
         // The vDSP.DiscreteFourierTransform initializer returns an optional
         // instance. If the transform cannot be created, simply return offset 0.
-        guard let dft = vDSP.DiscreteFourierTransform(count: fadeSamples,
-                                                      direction: .forward,
-                                                      transformType: .complexReal,
-                                                      ofType: Float.self) else {
+        guard let dft = try? vDSP.DiscreteFourierTransform(count: fadeSamples,
+                                                           direction: .forward,
+                                                           transformType: .complexReal,
+                                                           ofType: Float.self) else {
             return 0
         }
 
@@ -23,9 +23,11 @@ struct SpectralLoopAnalyzer {
         var startSegment = [Float](repeating: 0, count: fadeSamples)
         vDSP_vmul(channel, 1, window, 1, &startSegment, 1, vDSP_Length(fadeSamples))
 
+        var startImagInput = [Float](repeating: 0, count: fadeSamples)
         var startReal = [Float](repeating: 0, count: fadeSamples/2)
         var startImag = [Float](repeating: 0, count: fadeSamples/2)
         dft.transform(inputReal: startSegment,
+                      inputImaginary: startImagInput,
                       outputReal: &startReal,
                       outputImaginary: &startImag)
         var startMag = [Float](repeating: 0, count: fadeSamples/2)
@@ -48,7 +50,9 @@ struct SpectralLoopAnalyzer {
             if endStart < 0 || endStart + fadeSamples > totalFrames { continue }
 
             vDSP_vmul(channel + endStart, 1, window, 1, &candidate, 1, vDSP_Length(fadeSamples))
+            var candImagInput = [Float](repeating: 0, count: fadeSamples)
             dft.transform(inputReal: candidate,
+                          inputImaginary: candImagInput,
                           outputReal: &candReal,
                           outputImaginary: &candImag)
             for i in 0..<(fadeSamples/2) {


### PR DESCRIPTION
## Summary
- fix DFT initialization using `try?`
- provide imaginary input arrays when calling `transform`

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68416c149c408323a272dfcd929cba73