### PR TITLE
Add crossfade mode combo box

### DIFF
--- a/LoopSmith/AudioFileItem.swift
+++ b/LoopSmith/AudioFileItem.swift
@@ -12,10 +12,8 @@ struct AudioFileItem: Identifiable {
     var progress: Double = 0.0
     var exportedURL: URL? = nil
     var waveform: [Float] = []
-    var analyzePerfectPoint: Bool = false
-  	var crossfadeMode: CrossfadeMode = .manual
+    var crossfadeMode: CrossfadeMode = .manual
     var bpm: Double? = nil
-    var analyzePerfectPoint: Bool = false
     let format: AudioFileFormat
 
     /// Returns the output URL for this file when exported to the given directory
@@ -32,7 +30,7 @@ struct AudioFileItem: Identifiable {
         return String(format: "%d:%02d", minutes, seconds)
     }
     
-    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], crossfadeMode: CrossfadeMode = .manual, bpm: Double? = nil, analyzePerfectPoint: Bool = false) {
+    init(url: URL, fadeDurationMs: Double, duration: TimeInterval, waveform: [Float] = [], crossfadeMode: CrossfadeMode = .manual, bpm: Double? = nil) {
         self.url = url
         self.fileName = url.lastPathComponent
         self.fadeDurationMs = fadeDurationMs
@@ -42,7 +40,6 @@ struct AudioFileItem: Identifiable {
         self.format = format
         self.duration = duration
         self.waveform = waveform
-        self.analyzePerfectPoint = analyzePerfectPoint
         self.crossfadeMode = crossfadeMode
         self.bpm = bpm
     }

--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -139,30 +139,23 @@ struct ContentView: View {
             // Appliquer le modificateur `.width(min:ideal:)` à la colonne Fade (%)
             .width(min: 200, ideal: 260)
 
-            TableColumn("Rhythm Sync") { file in
-                Toggle("", isOn: Binding(
-                    get: { file.rhythmSync },
+            TableColumn("Crossfade Mode") { file in
+                Picker("", selection: Binding(
+                    get: { file.crossfadeMode },
                     set: { newVal in
                         if let idx = audioFiles.firstIndex(where: { $0.id == file.id }) {
-                            audioFiles[idx].rhythmSync = newVal
+                            audioFiles[idx].crossfadeMode = newVal
                         }
                     }
-                ))
+                )) {
+                    ForEach(CrossfadeMode.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
                 .labelsHidden()
                 .padding(.vertical, 6)
                 .padding(.horizontal, 8)
                 .background(RoundedRectangle(cornerRadius: 6).fill(Color.backgroundSecondary))
-            }
-            TableColumn("Rhythmic Recomposition") { file in
-                Toggle("", isOn: Binding(
-                    get: { file.rhythmicRecomposition },
-                    set: { newVal in
-                        if let idx = audioFiles.firstIndex(where: { $0.id == file.id }) {
-                            audioFiles[idx].rhythmicRecomposition = newVal
-                        }
-                    }
-                ))
-                .labelsHidden()
             }
             TableColumn("Preview") { file in
                 PreviewButton(file: file, isExporting: $isExporting)

--- a/LoopSmith/CrossfadeMode.swift
+++ b/LoopSmith/CrossfadeMode.swift
@@ -2,7 +2,8 @@ import Foundation
 
 enum CrossfadeMode: String, CaseIterable, Identifiable {
     case manual
-    case rhythmicBPM
+    case beatDetection
+    case spectral
 
     var id: Self { self }
 
@@ -10,8 +11,10 @@ enum CrossfadeMode: String, CaseIterable, Identifiable {
         switch self {
         case .manual:
             return "Manual"
-        case .rhythmicBPM:
-            return "Rhythmic (BPM)"
+        case .beatDetection:
+            return "Beat Detection"
+        case .spectral:
+            return "Spectral"
         }
     }
 }

--- a/LoopSmith/PreviewPlayer.swift
+++ b/LoopSmith/PreviewPlayer.swift
@@ -130,7 +130,6 @@ struct PreviewButton: View {
             outputURL: tmpURL,
             fadeDurationMs: file.fadeDurationMs,
             format: file.format,
-            analyzePerfectPoint: file.analyzePerfectPoint,
             crossfadeMode: file.crossfadeMode,
             bpm: file.bpm,
             progress: { percent in

--- a/LoopSmith/SeamlessProcessor.swift
+++ b/LoopSmith/SeamlessProcessor.swift
@@ -38,9 +38,10 @@ struct SeamlessProcessor {
                 let midFrame = total / 2
                 var fadeSamples = max(1, Int(sampleRate * fadeDurationMs / 1000.0))
 
-                let rhythmSync = (crossfadeMode == .rhythmicBPM)
+                let beatDetection = (crossfadeMode == .beatDetection)
+                let spectral = (crossfadeMode == .spectral)
 
-                if rhythmSync, let bpm = bpm {
+                if beatDetection, let bpm = bpm {
                     let beatFrames = Int(sampleRate * 60.0 / bpm)
                     if beatFrames > 0 {
                         let multiples = max(1, Int(round(Double(fadeSamples) / Double(beatFrames))))
@@ -49,7 +50,7 @@ struct SeamlessProcessor {
                 }
 
                 var offsetFrames = 0
-                if rhythmSync {
+                if beatDetection {
                     let searchRange = min(fadeSamples, max(0, total - fadeSamples * 2))
                     if searchRange > 0, numChannels > 0 {
                         let channel = inputChannels[0]
@@ -74,7 +75,9 @@ struct SeamlessProcessor {
                             off += step
                         }
                     }
-                if analyzePerfectPoint, numChannels > 0 {
+                }
+
+                if spectral, numChannels > 0 {
                     let channel = inputChannels[0]
                     offsetFrames = SpectralLoopAnalyzer.bestOffset(
                         channel: channel,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project provides tools for seamless looping of audio files.
 
 ## Features
 - Import multiple audio files, adjust fade lengths and preview loops.
-- Crossfade mode combobox selects manual or BPM-synced loops.
+ - Crossfade mode combobox selects between Manual, Beat Detection or Spectral modes.
 - BPM detection and automatic fade adjustment to match one measure.
 - Simple auto-quantization of loops on export.
 


### PR DESCRIPTION
## Summary
- add `beatDetection` and `spectral` modes to `CrossfadeMode`
- use a picker in the UI to select crossfade mode instead of toggles
- update `SeamlessProcessor` to handle new modes
- remove deprecated `analyzePerfectPoint` option
- update README

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6842ae89b5b8832399efea25aaeebb4e