### PR TITLE
Fix unmatched braces in ContentView

### DIFF
--- a/LoopSmith/ContentView.swift
+++ b/LoopSmith/ContentView.swift
@@ -180,9 +180,10 @@ struct ContentView: View {
                 }
             }
             .frame(minHeight: 200)
-            .onDrop(of: [UTType.fileURL.identifier], isTargeted: nil) { providers in
-                handleDrop(providers: providers)
-            TableColumn("Exported Path") { file in
+        .onDrop(of: [UTType.fileURL.identifier], isTargeted: nil) { providers in
+            handleDrop(providers: providers)
+        }
+        TableColumn("Exported Path") { file in
                 Text(file.exportedURL?.path ?? "-")
                     .lineLimit(1)
                     .padding(.vertical, 6)


### PR DESCRIPTION
## Summary
- close the `.onDrop` modifier in ContentView

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6842b4ea07ec83238c3af3341c16fc28