### PR TITLE
Disable code signing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build app and create DMG
         run: |
-          xcodebuild -scheme LoopSmith -configuration Release -derivedDataPath build
+          xcodebuild -scheme LoopSmith -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO
           mkdir dmg
           cp -R build/Build/Products/Release/LoopSmith.app dmg/
           hdiutil create -volname LoopSmith -srcfolder dmg -ov -format UDZO LoopSmith-${GITHUB_REF_NAME}.dmg


### PR DESCRIPTION
## Summary
- skip code signing during CI build

## Testing
- `swift test` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_6842c64bc9bc832388ee11df56dfd35c