### PR TITLE
Update docs for macOS 13 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "LoopSmith",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v13)
     ],
     products: [
         .executable(name: "LoopSmith", targets: ["LoopSmith"])

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ready-to-use loop files.
 - Output formats: WAV or AIFF. Exported files are prefixed with `LOOP_`.
 
 ## System Requirements
-- macOS 12.0 or later
+- macOS 13.0 or later
 - 4 GB RAM minimum recommended
 - 100 MB available disk space
 
@@ -34,7 +34,7 @@ ready-to-use loop files.
 - Use manual mode for precise control over transition points.
 
 ## Building from Source
-The project targets macOS 12 or later. Open `LoopSmith.xcodeproj` in Xcode and
+The project targets macOS 13 or later. Open `LoopSmith.xcodeproj` in Xcode and
 build the application, or use Swift Package Manager:
 
 ```bash

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,7 +135,7 @@
 
         <h2>Requirements</h2>
         <ul>
-            <li>macOS 11.0 or later</li>
+            <li>macOS 13.0 or later</li>
             <li>100MB of free disk space</li>
         </ul>
 


### PR DESCRIPTION
## Summary
- bump supported macOS version to 13 in documentation and Package manifest

## Testing
- `swift build` *(fails: no such module 'UniformTypeIdentifiers')*

------
https://chatgpt.com/codex/tasks/task_e_68457527f1148323aee8d2d909f81d01